### PR TITLE
Shuffled board on every play, to remove biases towards played cards

### DIFF
--- a/server/controller/roomController.ts
+++ b/server/controller/roomController.ts
@@ -269,6 +269,8 @@ export class RoomController {
 			room.placeCardsOnBoard(numToDraw);
 		}
 
+		room.board = shuffle(room.board);
+
 		// Update database records
 		await room.save();
 


### PR DESCRIPTION
My roommate was playing this game and looking for a strategy to get better at it. He realized that once a set is played, the next set almost always included the cards that get drawn, so he relied on the position of the drawn/replaced cards to find the next set.

This PR shuffles the board after each play, to keep this strategy from being effective.