### PR TITLE
Fix card glitching, remove inactive players, and small fixes

### DIFF
--- a/client/App.svelte
+++ b/client/App.svelte
@@ -6,7 +6,7 @@
 	let roomCode =
 		new URLSearchParams(window.location.search).get('room') || '';
 
-	socket.on('roomCreated', function(data) {
+	socket.on('roomCreated', data => {
 		const queryParams = new URLSearchParams();
 		queryParams.set('room', data.roomCode);
 		window.location.search = '?' + queryParams.toString();

--- a/client/game/GameView.svelte
+++ b/client/game/GameView.svelte
@@ -35,7 +35,7 @@
 		}
 	}
 
-	socket.on('joinedSuccessfully', function(data) {
+	socket.on('joinedSuccessfully', data => {
 		loadRoom(data);
 		if (data.started) {
 			if (data.board.length > 0) {
@@ -49,17 +49,17 @@
 		localStorage.setItem('oldConnectionId', socket.id);
 	});
 
-	socket.on('roomStarted', function(data) {
+	socket.on('roomStarted', data => {
 		loadRoom(data);
 		state = 'playing';
 		plays = [];
 	});
 
-	socket.on('gameOver', function() {
+	socket.on('gameOver', () => {
 		state = 'ended';
 	});
 
-	socket.on('movePlayed', function(data) {
+	socket.on('movePlayed', data => {
 		loadRoom(data);
 		plays = [
 			{
@@ -79,7 +79,7 @@
 		});
 	});
 
-	socket.on('playerDisconnected', function(connectionId) {
+	socket.on('playerDisconnected', connectionId => {
 		players.forEach(player => {
 			if (player.connectionId == connectionId) {
 				player.connected = false;
@@ -89,14 +89,14 @@
 		players = players;
 	});
 
-	socket.on('playersRemoved', function(data) {
+	socket.on('playersRemoved', data => {
 		const removedPlayers = data.removedPlayers;
 		players = players.filter(
 			player => !removedPlayers.includes(player.connectionId)
 		);
 	});
 
-	socket.on('newPlayer', function(player) {
+	socket.on('newPlayer', player => {
 		players = [
 			{
 				connectionId: player.connectionId,

--- a/client/game/PauseScreen.svelte
+++ b/client/game/PauseScreen.svelte
@@ -23,6 +23,7 @@
 	function handleKeydown(e) {
 		if (['Enter', 'Space'].includes(e.code)) {
 			startGame();
+			e.preventDefault();
 		}
 	}
 </script>

--- a/client/game/Sidebar.svelte
+++ b/client/game/Sidebar.svelte
@@ -30,10 +30,6 @@
 		transition: opacity 0.3s ease-in-out;
 	}
 
-	.player.afk {
-		opacity: 0.4;
-	}
-
 	.player strong {
 		flex: 1;
 		white-space: nowrap;
@@ -57,11 +53,10 @@
 	</div>
 </div>
 
-{#each players.sort((a, b) => b.points - a.points) as player (player.connectionId)}
-	<div
-		class="player"
-		class:afk={!player.connected}
-		animate:flip={{ duration: 300 }}>
+{#each players
+	.filter(player => player.connected)
+	.sort((a, b) => b.points - a.points) as player (player.connectionId)}
+	<div class="player" animate:flip={{ duration: 300 }}>
 		<strong transition:fly={{ x: -20, duration: 300 }}>
 			{player.name}
 		</strong>

--- a/client/game/board/Board.svelte
+++ b/client/game/board/Board.svelte
@@ -5,7 +5,7 @@
 	import { scale, fly } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
 	import { socket } from '../../connectivity.js';
-	import { areCardsEqual, arrayContainsCard } from '../shared.js';
+	import { areCardsEqual, arrayContainsCard, justCard } from '../shared.js';
 
 	const keyboardMap = ['qwertyu', 'asdfghj', 'zxcvbnm'].map(line =>
 		line.split('')
@@ -54,7 +54,7 @@
 		}
 	}
 
-	socket.on('movePlayed', function(data) {
+	socket.on('movePlayed', data => {
 		if (data.player.connectionId == socket.id) {
 			attemptSelectionClear();
 		} else {
@@ -64,9 +64,16 @@
 		}
 	});
 
+	socket.on('exception', data => {
+		if (isSubmitting && data.includes('Error')) {
+			attemptSelectionClear();
+		}
+	});
+
 	function handleKeydown(e) {
 		if (['Backspace', 'Escape', 'Delete'].includes(e.code)) {
 			selection = [];
+			e.preventDefault();
 		}
 	}
 
@@ -80,28 +87,25 @@
 
 <style>
 	.board {
+		display: inline-flex;
+		flex-wrap: wrap;
 		margin: auto;
 		font-size: 0;
 		width: 360px;
 		padding: 12px 12px 0 0;
-		text-align: center;
 		box-sizing: border-box;
 	}
 
 	.card-wrapper {
 		margin: 0 0 12px 12px;
-		display: inline-block;
 	}
 
 	@media only screen and (min-width: 500px) {
 		.board {
+			flex-direction: column;
+			align-content: center;
 			width: 100%;
 			height: 390px;
-			display: inline-flex;
-			flex-direction: column;
-			flex-wrap: wrap;
-			align-items: flex-start;
-			align-content: center;
 			padding: 20px 20px 0 0;
 		}
 
@@ -120,7 +124,7 @@
 				in:fly={{ y: 30, duration: 300, delay: cardDelay(i) }}
 				out:fly={{ y: -30, duration: 300, delay: cardDelay(i) }}>
 				<Card
-					{...card}
+					{...justCard(card)}
 					selected={arrayContainsCard(selection, card)}
 					on:click={cardClicked}
 					letter={getKey(i)} />

--- a/client/game/board/Card.svelte
+++ b/client/game/board/Card.svelte
@@ -6,7 +6,7 @@
 	import CardSymbol from './CardSymbol.svelte';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
-	import { arrayContainsCard } from '../shared.js';
+	import { arrayContainsCard, hasModifierKey } from '../shared.js';
 
 	const dispatch = createEventDispatcher();
 	let humanReadable =
@@ -31,8 +31,9 @@
 	}
 
 	function handleKeydown(e) {
-		if (e.code == 'Key' + letter) {
+		if (e.code == 'Key' + letter && !hasModifierKey(e)) {
 			click();
+			e.preventDefault();
 		}
 	}
 </script>
@@ -48,7 +49,7 @@
 		cursor: pointer;
 		border-radius: 0.3em;
 		transition: all 0.2s ease-in-out;
-		background: rgba(255, 255, 255, 0.3);
+		background: var(--cardBgColor);
 	}
 
 	.card:hover {
@@ -95,11 +96,11 @@
 
 <svelte:window on:keydown={handleKeydown} />
 
-<div class="card" title={humanReadable} on:click={click}>
+<div class="card" aria-label={humanReadable} on:click={click}>
 	<CardSymbol {shape} {fillStyle} {color} {number} />
 	<div class="letter">{letter}</div>
 	{#if selected}
-		<div in:fade={{ duration: 100 }} out:fade={{ duration: 300 }}>
+		<div in:fade={{ duration: 100 }} out:fade={{ duration: 200 }}>
 			<div class="selection-border" />
 		</div>
 	{/if}

--- a/client/game/shared.js
+++ b/client/game/shared.js
@@ -6,25 +6,21 @@ const cardStructure = {
 };
 
 export function areCardsEqual(a, b) {
-	let isSame = true;
-	Object.keys(cardStructure).forEach((property) => {
+	for (const property of Object.keys(cardStructure)) {
 		if (a[property] !== b[property]) {
-			isSame = false;
-			return;
+			return false;
 		}
-	});
-	return isSame;
+	}
+	return true;
 }
 
 export function arrayContainsCard(list, card) {
-	let doesContain = false;
-	list.forEach((current) => {
+	for (const current of list) {
 		if (areCardsEqual(current, card)) {
-			doesContain = true;
-			return;
+			return true;
 		}
-	});
-	return doesContain;
+	}
+	return false;
 }
 
 function randomElement(list) {
@@ -33,18 +29,17 @@ function randomElement(list) {
 
 export function randomCard() {
 	let card = {};
-	Object.keys(cardStructure).forEach((property) => {
+	for (const property of Object.keys(cardStructure)) {
 		card[property] = randomElement(cardStructure[property]);
-	});
+	}
 	return card;
 }
 
 export function isValidPlay(cards) {
 	if (cards.length != 3) return false;
 
-	let isValid = true;
 	const [a, b, c] = cards;
-	Object.keys(cardStructure).forEach((property) => {
+	for (const property of Object.keys(cardStructure)) {
 		// written this way for easier understanding
 		if (a[property] === b[property] && b[property] === c[property]) {
 			// a = b = c, we good
@@ -55,16 +50,15 @@ export function isValidPlay(cards) {
 		) {
 			// a != b != c, we good
 		} else {
-			isValid = false;
-			return;
+			return false;
 		}
-	});
-	return isValid;
+	}
+	return true;
 }
 
 export function cardAsString(card) {
 	let result = '';
-	Object.keys(cardStructure).forEach((property) => {
+	Object.keys(cardStructure).forEach(property => {
 		result += card[property];
 	});
 	return result;
@@ -72,7 +66,7 @@ export function cardAsString(card) {
 
 export function inPlaceReplace(before, after) {
 	let final = [];
-	before.forEach((card) => {
+	before.forEach(card => {
 		// is the card still there?
 		let index = -1;
 		after.forEach((current, i) => {
@@ -92,10 +86,27 @@ export function inPlaceReplace(before, after) {
 		}
 	});
 	// replace all placeholders with new elements
-	final = final.map((card) => card || after.pop());
+	final = final.map(card => card || after.pop());
 	// remove any placeholders that weren't filled
-	final = final.filter((card) => !!card);
+	final = final.filter(card => !!card);
 	// add any remaining elements
 	final = [...final, ...after];
 	return final;
+}
+
+export function justCard(card) {
+	let filtered = {};
+	for (const property of Object.keys(cardStructure)) {
+		filtered[property] = card[property];
+	}
+	return filtered;
+}
+
+export function hasModifierKey(e) {
+	for (const modifier of ['Alt', 'Control', 'Meta', 'Shift']) {
+		if (e.getModifierState(modifier)) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/public/global.css
+++ b/public/global.css
@@ -1,5 +1,6 @@
 :root {
 	--bgColor: #eff0d1;
+	--cardBgColor: #f9f9ee;
 	--saturatedColor: #225560;
 	--textColor: #2e282a;
 }


### PR DESCRIPTION
- hide inactive players instead of just fading them out
- fix card glitching when they are swapped out on narrow screens
- lighten card color
- prevent default action on keyboard shortcuts
- initialize cards without id to prevent console warning
- put card description in aria-label instead of title to prevent tooltip
- code style changes (use arrow functions for socket event handlers and use for/of instead of forEach)
- slightly shorten highlight fade out time