### PR TITLE
Kick players off others sessions when opening new tab

### DIFF
--- a/client/game/GameView.svelte
+++ b/client/game/GameView.svelte
@@ -47,6 +47,7 @@
 			state = 'waiting';
 		}
 		localStorage.setItem('old connection id', socket.id);
+		localStorage.removeItem('new tab ' + roomCode);
 	});
 
 	socket.on('roomStarted', data => {
@@ -112,13 +113,13 @@
 	});
 
 	function closeIfDuplicate(e) {
-		if (e.key == 'new tab') {
-			const newTabConnectionId = localStorage.getItem('new tab');
+		if (e.key == 'new tab ' + roomCode) {
+			const newTabConnectionId = localStorage.getItem(
+				'new tab ' + roomCode
+			);
 			if (newTabConnectionId && newTabConnectionId != socket.id) {
 				socket.close();
 				window.location = window.location;
-			} else {
-				localStorage.removeItem('new tab');
 			}
 		}
 	}

--- a/client/game/GameView.svelte
+++ b/client/game/GameView.svelte
@@ -46,7 +46,7 @@
 		} else {
 			state = 'waiting';
 		}
-		localStorage.setItem('oldConnectionId', socket.id);
+		localStorage.setItem('old connection id', socket.id);
 	});
 
 	socket.on('roomStarted', data => {
@@ -110,6 +110,18 @@
 			),
 		];
 	});
+
+	function closeIfDuplicate(e) {
+		if (e.key == 'new tab') {
+			const newTabConnectionId = localStorage.getItem('new tab');
+			if (newTabConnectionId && newTabConnectionId != socket.id) {
+				socket.close();
+				window.location = window.location;
+			} else {
+				localStorage.removeItem('new tab');
+			}
+		}
+	}
 </script>
 
 <style>
@@ -175,6 +187,8 @@
 		}
 	}
 </style>
+
+<svelte:window on:storage={closeIfDuplicate} />
 
 <div class="game">
 	{#if state == 'joining'}

--- a/client/game/JoinPrompt.svelte
+++ b/client/game/JoinPrompt.svelte
@@ -25,7 +25,6 @@
 		} else {
 			localStorage.removeItem('name');
 		}
-		localStorage.setItem('new tab', socket.id);
 		attemptJoin();
 		joining = true;
 	}
@@ -43,6 +42,7 @@
 			unavailable = true;
 			joining = false;
 		} else if (data.includes('already in')) {
+			localStorage.setItem('new tab ' + roomCode, socket.id);
 			setTimeout(attemptJoin, 100);
 		}
 	});

--- a/client/game/JoinPrompt.svelte
+++ b/client/game/JoinPrompt.svelte
@@ -25,18 +25,25 @@
 		} else {
 			localStorage.removeItem('name');
 		}
-		socket.emit('joinRoom', {
-			roomCode: roomCode,
-			playerName: playerName || randomName,
-			oldConnectionId: localStorage.getItem('oldConnectionId'),
-		});
+		localStorage.setItem('new tab', socket.id);
+		attemptJoin();
 		joining = true;
 	}
 
+	function attemptJoin() {
+		socket.emit('joinRoom', {
+			roomCode: roomCode,
+			playerName: playerName || randomName,
+			oldConnectionId: localStorage.getItem('old connection id'),
+		});
+	}
+
 	socket.on('exception', data => {
-		if (data.includes('EntityNotFound') || data.includes('already in')) {
+		if (data.includes('EntityNotFound')) {
 			unavailable = true;
 			joining = false;
+		} else if (data.includes('already in')) {
+			setTimeout(attemptJoin, 100);
 		}
 	});
 


### PR DESCRIPTION
If a players opens a new tab in the same browser (i.e. they share storage) and joins a game, old tabs connected to the same room will close their socket and refresh themselves to allow the new tab to join the session. Cross-tab communication is done using local storage.