### PR TITLE
Add text explanations and labels, improve presentation of card breakdown

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -18,11 +18,6 @@ jobs:
         run: |
           npm install
           npm run build:client
-      - name: Cachebust
-        run: |
-          echo $GITHUB_SHA
-          sed -i 's/BUILD_ID/$GITHUB_SHA/g' public/index.html
-          cat public/index.html
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -18,7 +18,11 @@ jobs:
         run: |
           npm install
           npm run build:client
+      - name: Cachebust
+        run: |
+          echo $GITHUB_SHA
           sed -i 's/BUILD_ID/$GITHUB_SHA/g' public/index.html
+          cat public/index.html
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:

--- a/client/NoLanding.svelte
+++ b/client/NoLanding.svelte
@@ -1,0 +1,7 @@
+<svelte:head>
+	<style>
+		main {
+			display: none;
+		}
+	</style>
+</svelte:head>

--- a/client/game/GameView.svelte
+++ b/client/game/GameView.svelte
@@ -1,6 +1,7 @@
 <script>
 	export let roomCode;
 
+	import NoLanding from '../NoLanding.svelte';
 	import Board from './board/Board.svelte';
 	import Sidebar from './Sidebar.svelte';
 	import Ticker from './Ticker.svelte';
@@ -164,7 +165,7 @@
 		-webkit-user-select: none;
 		user-select: none;
 		background: var(--bgColor);
-		color: var(--textColor);
+		color: var(--saturatedColor);
 	}
 
 	.ticker {
@@ -173,6 +174,7 @@
 		left: 0;
 		right: 0;
 		overflow: hidden;
+		color: var(--textColor);
 	}
 
 	.main {
@@ -266,6 +268,7 @@
 	}
 </style>
 
+<NoLanding />
 <svelte:window on:storage={closeIfDuplicate} />
 
 <div class="game">

--- a/client/game/JoinPrompt.svelte
+++ b/client/game/JoinPrompt.svelte
@@ -97,6 +97,7 @@
 		<div class="blink error">?</div>
 		<!-- svelte-ignore a11y-autofocus -->
 		<button type="button" class="large" on:click={back} autofocus>
+			<span>Back</span>
 			&larr;
 		</button>
 	{:else}
@@ -107,7 +108,10 @@
 				bind:value={playerName}
 				placeholder={randomName}
 				autofocus />
-			<button type="submit" class="large">&rarr;</button>
+			<button type="submit" class="large">
+				<span>Join</span>
+				&rarr;
+			</button>
 		</form>
 	{/if}
 </div>

--- a/client/game/PauseScreen.svelte
+++ b/client/game/PauseScreen.svelte
@@ -30,7 +30,7 @@
 
 <style>
 	.paused-wrapper {
-		padding: 3em 0;
+		padding: 2em 0 4em 0;
 		height: 100%;
 		width: 100%;
 		position: absolute;
@@ -54,6 +54,16 @@
 		position: relative;
 		font-size: 0;
 		cursor: inherit;
+	}
+
+	button .label {
+		position: absolute;
+		top: 100%;
+		left: 50%;
+		transform: translateX(-50%);
+		font-size: 16px;
+		padding: 1em;
+		text-transform: uppercase;
 	}
 
 	.arrow:after {
@@ -119,6 +129,20 @@
 			stroke-dasharray: 0 16px 188px 188px 188px 999px;
 		}
 	}
+
+	button.redo .label {
+		opacity: 0;
+		animation: waiting-fade-in 0.3s linear 5.3s forwards;
+	}
+
+	@keyframes waiting-fade-in {
+		0% {
+			opacity: 0;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 </style>
 
 <svelte:window on:keydown={handleKeydown} />
@@ -135,8 +159,11 @@
 					cy={size / 2} />
 			</svg>
 			<div class="arrow" />
+			<span class="label">Restart</span>
 		</button>
 	{:else}
-		<button class="arrow" />
+		<button class="arrow">
+			<span class="label">Play</span>
+		</button>
 	{/if}
 </div>

--- a/client/game/board/Board.svelte
+++ b/client/game/board/Board.svelte
@@ -116,6 +116,7 @@
 		width: 360px;
 		padding: 12px 12px 0 0;
 		box-sizing: border-box;
+		color: var(--textColor);
 	}
 
 	.card-wrapper {

--- a/client/game/shared.js
+++ b/client/game/shared.js
@@ -23,7 +23,7 @@ export function arrayContainsCard(list, card) {
 	return false;
 }
 
-function randomElement(list) {
+export function randomElement(list) {
 	return list[Math.floor(Math.random() * list.length)];
 }
 

--- a/client/game/tutorial/MiniExplainer.svelte
+++ b/client/game/tutorial/MiniExplainer.svelte
@@ -60,7 +60,7 @@
 <div class="cover center-contents" transition:fade={{ duration: 200 }}>
 	<div class="explained" transition:fly={{ y: 30, duration: 200 }}>
 		<div class="tutorial-wrapper">
-			<TutorialBreakdown {cards} breakdownDepth={4} resultScale={0.8} />
+			<TutorialBreakdown {cards} resultScale={0.8} />
 		</div>
 		<button
 			on:click={understood}

--- a/client/game/tutorial/Tutorial.svelte
+++ b/client/game/tutorial/Tutorial.svelte
@@ -1,15 +1,11 @@
 <script>
+	export let text = 'Play';
+
 	import TutorialBreakdown from './TutorialBreakdown.svelte';
-	import { createEventDispatcher } from 'svelte';
-	import { generateSet } from '../shared.js';
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { generateSet, randomElement } from '../shared.js';
 
 	const dispatch = createEventDispatcher();
-
-	const simple = [
-		[{}, {}, {}],
-		[{}, { shape: 'square' }, { shape: 'triangle' }],
-		[{}, {}, { shape: 'triangle' }],
-	];
 
 	const samples = [
 		generateSet('correct'),
@@ -20,26 +16,42 @@
 		generateSet('almost'),
 	];
 
+	let loaded = [];
+
+	function loadMore() {
+		let added = [];
+		for (let i = 0; i < 4; i++) {
+			added.push(
+				generateSet(
+					randomElement(['correct', 'correct', 'almost', 'random'])
+				)
+			);
+		}
+		loaded = [...loaded, ...added];
+	}
+
 	function confirm() {
 		dispatch('complete');
 	}
+
+	const observer = new IntersectionObserver(loadMore);
+
+	onMount(async () => {
+		observer.observe(document.querySelector('.placeholder.slide'));
+	});
 </script>
 
 <style>
 	.tutorial-wrapper {
-		padding-bottom: 2em;
-		min-height: 100vh;
-		box-sizing: border-box;
-		margin-bottom: env(safe-area-inset-bottom);
 		text-align: center;
+		padding-bottom: 2em;
 	}
 
-	.explanation {
-		margin: 0 1em;
+	h2 {
+		margin-top: 2em;
 	}
 
 	.slides {
-		margin: -1em 0 1em 0;
 		max-width: 800px;
 		text-align: center;
 	}
@@ -55,6 +67,10 @@
 		width: 320px;
 	}
 
+	.placeholder {
+		height: 200px;
+	}
+
 	@media only screen and (max-width: 500px) {
 		.slides {
 			width: 100%;
@@ -68,11 +84,11 @@
 </style>
 
 <div class="tutorial-wrapper center-contents">
-	<h2>Tutorial</h2>
-	<div class="explanation">
-		Form sets of three cards where the shape, fill, number, and color are
-		all the same or different.
-	</div>
+	<!-- svelte-ignore a11y-autofocus -->
+	<button class="large" on:click={confirm} autofocus>
+		<span>{text}</span>
+		&rarr;
+	</button>
 	<h2>Examples</h2>
 	<div class="slides">
 		{#each samples as cards}
@@ -80,6 +96,12 @@
 				<TutorialBreakdown {cards} />
 			</div>
 		{/each}
+		{#each loaded as cards}
+			<div class="slide">
+				<TutorialBreakdown {cards} />
+			</div>
+		{/each}
+		<div class="placeholder slide" />
+		<div class="placeholder slide" />
 	</div>
-	<button class="large" on:click={confirm}>&rarr;</button>
 </div>

--- a/client/game/tutorial/Tutorial.svelte
+++ b/client/game/tutorial/Tutorial.svelte
@@ -17,6 +17,7 @@
 		generateSet('random'),
 		generateSet('almost'),
 		generateSet('almost'),
+		generateSet('almost'),
 	];
 
 	function confirm() {
@@ -26,14 +27,19 @@
 
 <style>
 	.tutorial-wrapper {
-		padding: 1em 0;
+		padding-bottom: 2em;
 		min-height: 100vh;
 		box-sizing: border-box;
 		margin-bottom: env(safe-area-inset-bottom);
+		text-align: center;
+	}
+
+	.explanation {
+		margin: 0 1em;
 	}
 
 	.slides {
-		margin-bottom: 1em;
+		margin: -1em 0 1em 0;
 		max-width: 800px;
 		text-align: center;
 	}
@@ -46,14 +52,7 @@
 		padding: 1em;
 		border-radius: 0.4em;
 		box-sizing: border-box;
-	}
-
-	.padded {
-		margin-bottom: 0.8em;
-	}
-
-	.padded:last-child {
-		margin-bottom: 0;
+		width: 320px;
 	}
 
 	@media only screen and (max-width: 500px) {
@@ -63,25 +62,22 @@
 
 		.slide {
 			flex-direction: column;
+			margin: 0.5em;
 		}
 	}
 </style>
 
 <div class="tutorial-wrapper center-contents">
+	<h2>Tutorial</h2>
+	<div class="explanation">
+		Form sets of three cards where the shape, fill, number, and color are
+		all the same or different.
+	</div>
+	<h2>Examples</h2>
 	<div class="slides">
-		{#each Array(samples.length + 1) as _, i}
+		{#each samples as cards}
 			<div class="slide">
-				{#if i == 0}
-					{#each simple as cards}
-						<div class="padded">
-							<TutorialBreakdown {cards} />
-						</div>
-					{/each}
-				{:else}
-					<TutorialBreakdown
-						cards={samples[i - 1]}
-						breakdownDepth={4} />
-				{/if}
+				<TutorialBreakdown {cards} />
 			</div>
 		{/each}
 	</div>

--- a/client/game/tutorial/TutorialBreakdown.svelte
+++ b/client/game/tutorial/TutorialBreakdown.svelte
@@ -1,6 +1,5 @@
 <script>
 	export let cards;
-	export let breakdownDepth = 0;
 	export let resultScale = 1;
 
 	import CardSymbol from '../board/CardSymbol.svelte';
@@ -8,7 +7,20 @@
 	import { areCardsEqual, isValidPlay } from '../shared.js';
 
 	const properties = ['shape', 'fillStyle', 'number', 'color']; // order matters so not pulled from shared.js
-	$: breakdown = properties.slice(0, breakdownDepth);
+
+	for (const i of [1, 2, 1]) {
+		for (const property of properties) {
+			// A != B != A
+			if (
+				cards[0][property] == cards[2][property] &&
+				cards[0][property] != cards[1][property]
+			) {
+				const flip = cards[0];
+				cards[0] = cards[i];
+				cards[i] = flip;
+			}
+		}
+	}
 
 	const defaultCard = {
 		shape: 'circle',
@@ -51,10 +63,6 @@
 		height: 60px;
 	}
 
-	.separated .combined {
-		border-top: 1em solid transparent;
-	}
-
 	.property {
 		position: relative;
 		height: 32px;
@@ -78,7 +86,7 @@
 
 <table>
 	<tbody>
-		{#each breakdown as property, i}
+		{#each properties as property, i}
 			<tr class="breakdown">
 				{#each cards as card, i}
 					<td class="property">
@@ -107,13 +115,13 @@
 				</td>
 			</tr>
 		{/each}
-		<tr class="main" class:separated={breakdownDepth > 0}>
+		<tr class="main">
 			{#each cards as card, i}
 				<td class="combined" style="transform:scale({resultScale})">
 					<CardSymbol {...combinedCard(card)} />
 				</td>
 				<td class="equality">
-					{#if breakdownDepth == 0 && i < cards.length - 1}
+					{#if i < cards.length - 1}
 						<TutorialEquality
 							equal={areCardsEqual(combinedCard(card), combinedCard(cards[i + 1]))} />
 					{/if}

--- a/client/home/HomeView.svelte
+++ b/client/home/HomeView.svelte
@@ -1,4 +1,6 @@
 <script>
+	import NoLanding from '../NoLanding.svelte';
+	import Tutorial from '../game/tutorial/Tutorial.svelte';
 	import { fade } from 'svelte/transition';
 	import { socket } from '../connectivity.js';
 
@@ -14,43 +16,15 @@
 	}
 </script>
 
-<style>
-	button {
-		position: relative;
-		font-size: 8em;
-		width: 1em;
-		height: 1em;
-		text-indent: -9em;
-		overflow: hidden;
-		padding: 0;
-	}
-
-	button:before,
-	button:after {
-		content: '';
-		display: block;
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		left: 50%;
-		border-left: 0.2em solid var(--saturatedColor);
-		transform: translateX(-50%) scale(0.5);
-	}
-
-	button:after {
-		transform: translateX(-50%) scale(0.5) rotate(90deg);
-	}
-</style>
-
 <svelte:window on:pageshow={popState} />
 
-<div class="cover center-contents">
-	{#if waiting}
-		<div in:fade={{ duration: 300, delay: 400 }}>
-			<div class="spinner" />
-		</div>
-	{:else}
-		<!-- svelte-ignore a11y-autofocus -->
-		<button on:click={createRoom} class="large" autofocus>go</button>
-	{/if}
-</div>
+{#if waiting}
+	<NoLanding />
+	<div class="cover center-contents" in:fade={{ duration: 300, delay: 400 }}>
+		<div class="spinner" />
+	</div>
+{:else}
+	<div out:fade={{ duration: 300 }}>
+		<Tutorial on:complete={createRoom} text="Create new" />
+	</div>
+{/if}

--- a/client/main.js
+++ b/client/main.js
@@ -1,7 +1,7 @@
 import App from './App.svelte';
 
 const app = new App({
-	target: document.body,
+	target: document.getElementById("app"),
 	props: {},
 });
 

--- a/public/global.css
+++ b/public/global.css
@@ -28,6 +28,25 @@ a:hover {
 	text-decoration: underline;
 }
 
+main {
+	max-width: 30em;
+	margin: auto;
+	padding: 1em;
+	line-height: 1.3;
+	text-align: justify;
+}
+
+h1 {
+	font-size: 2em;
+	margin: 0;
+	text-transform: uppercase;
+	letter-spacing: 0.1em;
+}
+
+h1 a:hover {
+	text-decoration: none;
+}
+
 h2 {
 	font-size: 1.4em;
 	margin: 1em 0;
@@ -82,14 +101,21 @@ button.large {
 	border: 0;
 	border-radius: 9em;
 	padding: 0.4em 1em;
-	margin: 0;
-	transition: 0.2s transform ease-in-out, 0.1s box-shadow ease-in-out;
+	margin: 0 auto;
+	transition: 0.1s box-shadow ease-in-out;
+	text-transform: uppercase;
+	display: flex;
+	align-items: center;
 }
 
 button.large:hover,
 button.large:focus {
-	transform: scale(1.1);
 	box-shadow: 0 0 0 6px var(--saturatedColor), 0 0 0 12px var(--bgColor);
+}
+
+button.large span {
+	font-size: 0.9em;
+	margin-right: 0.4em;
 }
 
 .center-contents {
@@ -126,6 +152,8 @@ button.large:focus {
 	right: 0;
 	bottom: 0;
 	z-index: 5;
+	background: var(--saturatedColor);
+	color: var(--bgColor);
 }
 
 .blink {
@@ -138,7 +166,6 @@ button.large:focus {
 	}
 }
 
-.no-js {
-	min-height: 100vh;
-	box-sizing: border-box;
+.faded {
+	opacity: 0.5;
 }

--- a/public/global.css
+++ b/public/global.css
@@ -28,6 +28,11 @@ a:hover {
 	text-decoration: underline;
 }
 
+h2 {
+	font-size: 1.4em;
+	margin: 1em 0;
+}
+
 label {
 	display: block;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -40,9 +40,9 @@
 		/>
 		<link rel="mask-icon" href="./safari-pinned-tab.svg" color="#225560" />
 
-		<link rel="stylesheet" href="./global.css?v=BUILD_ID" />
-		<link rel="stylesheet" href="./build/bundle.css?v=BUILD_ID" />
-		<script defer src="./build/bundle.js?v=BUILD_ID"></script>
+		<link rel="stylesheet" href="./global.css" />
+		<link rel="stylesheet" href="./build/bundle.css" />
+		<script defer src="./build/bundle.js"></script>
 	</head>
 	<body>
 		<main>

--- a/public/index.html
+++ b/public/index.html
@@ -6,12 +6,18 @@
 
 		<title>isaset</title>
 		<meta name="title" content="isaset" />
-		<meta name="description" content="▲ + ▨ + ◯ = ✓" />
+		<meta
+			name="description"
+			content="Play set online for free! ▲ + ▨ + ◯ = ✓"
+		/>
 
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://isaset.com/" />
 		<meta property="og:title" content="isaset" />
-		<meta property="og:description" content="▲ + ▨ + ◯ = ✓" />
+		<meta
+			property="og:description"
+			content="Play set online for free! ▲ + ▨ + ◯ = ✓"
+		/>
 		<meta property="og:image" content="https://isaset.com/preview.png" />
 		<meta property="twitter:card" content="summary_large_image" />
 
@@ -39,8 +45,23 @@
 		<script defer src="./build/bundle.js?v=BUILD_ID"></script>
 	</head>
 	<body>
-		<noscript class="no-js blink center-contents">
-			JavaScript is required to run this application.
-		</noscript>
+		<main>
+			<h1><a href="./">is a set</a></h1>
+			<p>
+				Play the popular card matching puzzle game online for free! Form
+				sets of three cards where the shape, fill, number, and color are
+				all the same or all different. There is always a set of three
+				cards.
+				<span class="faded">
+					This website is in no way affiliated with Set Enterprises,
+					Inc. &mdash; &copy; 2020
+				</span>
+			</p>
+		</main>
+		<p id="app">
+			<noscript class="cover blink center-contents">
+				JavaScript is required to run this application.
+			</noscript>
+		</p>
 	</body>
 </html>


### PR DESCRIPTION
- shuffle around cards in the case where A != B != A (no), it looks similar to A != B != C (yes)
- add text to explain tutorial (hopefully improving understanding and explaining this is not the game yet)
- remove breakdownDepth
- landing page with explanation
- labeled buttons
- attempt text replacement again on deploy