### PR TITLE
Consolidate state management using stores and simplify code

### DIFF
--- a/client/App.svelte
+++ b/client/App.svelte
@@ -2,10 +2,8 @@
 	import HomeView from './home/HomeView.svelte';
 	import GameView from './game/GameView.svelte';
 	import Tutorial from './game/tutorial/Tutorial.svelte';
-	import { socket } from './connectivity.js';
-
-	let roomCode =
-		new URLSearchParams(window.location.search).get('room') || '';
+	import { socket, closeAndReload } from './connectivity.js';
+	import { roomCode } from './stores.js';
 
 	let incompleteTutorial = !localStorage.getItem('tutorial complete');
 
@@ -14,8 +12,6 @@
 		queryParams.set('room', data.roomCode);
 		window.location.search = '?' + queryParams.toString();
 	});
-
-	socket.on('exception', console.error);
 
 	function tutorialComplete() {
 		localStorage.setItem('tutorial complete', 'yeah');
@@ -28,8 +24,7 @@
 				'new tab ' + roomCode
 			);
 			if (newTabConnectionId && newTabConnectionId != socket.id) {
-				socket.close();
-				window.location = window.location;
+				closeAndReload();
 			}
 		}
 	}
@@ -42,5 +37,5 @@
 {:else if incompleteTutorial}
 	<Tutorial on:complete={tutorialComplete} />
 {:else}
-	<GameView {roomCode} />
+	<GameView />
 {/if}

--- a/client/connectivity.js
+++ b/client/connectivity.js
@@ -1,2 +1,52 @@
 import io from 'socket.io-client';
+import { state, roomCode } from './stores.js';
+
 export const socket = io.connect('https://passt.herokuapp.com');
+
+export function requestRoomCreation() {
+	socket.emit('createRoom', { open: false });
+}
+
+export function requestJoinRoom(playerName) {
+	socket.emit('joinRoom', {
+		roomCode,
+		playerName,
+		oldConnectionId: localStorage.getItem('old connection id'),
+	});
+}
+
+export function startRoom() {
+	socket.emit('startRoom');
+}
+
+export function playCards(cards) {
+	socket.emit('play', {
+		cards: cards,
+	});
+}
+
+export function closeAndReload() {
+	socket.close();
+	window.location = window.location;
+}
+
+socket.on('joinedSuccessfully', () => {
+	localStorage.setItem('old connection id', socket.id);
+	localStorage.removeItem('new tab ' + roomCode);
+});
+
+let isJoining = false;
+state.subscribe(s => (isJoining = s == 'joining'));
+
+socket.on('exception', data => {
+	console.error(data);
+	if (!isJoining && data.includes('EntityNotFound')) {
+		closeAndReload();
+	}
+});
+
+socket.on('reconnect', () => {
+	if (!isJoining) {
+		requestJoinRoom($playerName);
+	}
+});

--- a/client/game/PauseScreen.svelte
+++ b/client/game/PauseScreen.svelte
@@ -1,7 +1,7 @@
 <script>
 	export let redo = false;
 
-	import { socket } from '../connectivity.js';
+	import { startRoom } from '../connectivity.js';
 
 	const size = 60;
 	const width = 6;
@@ -17,7 +17,7 @@
 		if (!allowed) {
 			return;
 		}
-		socket.emit('startRoom');
+		startRoom();
 	}
 
 	function handleKeydown(e) {

--- a/client/game/Sidebar.svelte
+++ b/client/game/Sidebar.svelte
@@ -1,14 +1,14 @@
 <script>
-	export let players = [];
-	export let roomCode;
+	export let players;
 
 	import ConnectivityIndicator from './ConnectivityIndicator.svelte';
 	import { fly, fade } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
-	import { socket } from '../connectivity.js';
+	import { socket, closeAndReload } from '../connectivity.js';
+	import { roomCode } from '../stores.js';
 
-	$: points = players.filter(player => player.connectionId == socket.id)[0]
-		.points;
+	$: myself = players.filter(player => player.connectionId == socket.id)[0];
+	$: points = myself ? myself.points : 0;
 	$: correctPlay = points > 0 ? true : false;
 
 	function selectAndCopy() {
@@ -23,7 +23,7 @@
 
 	function redoTutorial() {
 		localStorage.removeItem('tutorial complete');
-		window.location = window.location;
+		closeAndReload();
 	}
 </script>
 

--- a/client/game/Ticker.svelte
+++ b/client/game/Ticker.svelte
@@ -1,10 +1,9 @@
 <script>
-	export let plays = [];
-
 	import CardSymbol from './board/CardSymbol.svelte';
 	import { createEventDispatcher } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
+	import { plays } from '../stores.js';
 </script>
 
 <style>
@@ -57,7 +56,7 @@
 </style>
 
 <div class="ticker">
-	{#each plays as play (play.id)}
+	{#each $plays as play (play.id)}
 		<div
 			class="play"
 			class:invalid={!play.valid}

--- a/client/game/board/Board.svelte
+++ b/client/game/board/Board.svelte
@@ -6,7 +6,7 @@
 	import { createEventDispatcher } from 'svelte';
 	import { scale, fly } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
-	import { socket } from '../../connectivity.js';
+	import { socket, playCards } from '../../connectivity.js';
 	import {
 		areCardsEqual,
 		arrayContainsCard,
@@ -19,6 +19,7 @@
 		line.split('')
 	);
 	const NUM_CARDS_FOR_PLAY = 3;
+	const EXPLAIN_MISPLAY = 5;
 
 	function getKey(i) {
 		if (i >= keyboardMap.length * keyboardMap[0].length) {
@@ -31,7 +32,7 @@
 	let selection = [];
 	let isSubmitting = false;
 	let selectionDeselectClearSteps = 2;
-	let incorrectStreak = 0;
+	let incorrectStreak = EXPLAIN_MISPLAY; // assume they don't know
 
 	function attemptSelectionClear() {
 		selectionDeselectClearSteps--;
@@ -63,14 +64,14 @@
 					incorrectStreak = 0;
 				} else {
 					incorrectStreak++;
-					dispatch('misplay', {
-						count: incorrectStreak,
-						cards: selection,
-					});
+					if (incorrectStreak > EXPLAIN_MISPLAY) {
+						dispatch('misplay', {
+							count: incorrectStreak,
+							cards: selection,
+						});
+					}
 				}
-				socket.emit('play', {
-					cards: selection,
-				});
+				playCards(selection);
 				setTimeout(attemptSelectionClear, 300);
 			}
 		}

--- a/client/game/tutorial/MiniExplainer.svelte
+++ b/client/game/tutorial/MiniExplainer.svelte
@@ -34,11 +34,11 @@
 
 	.explained {
 		margin: 1em;
+		color: var(--textColor);
 	}
 
 	.tutorial-wrapper {
 		background: var(--cardBgColor);
-		color: var(--saturatedColor);
 		border: 1px solid rgba(0, 0, 0, 0.1);
 		padding: 1em;
 		border-radius: 0.3em;

--- a/client/game/tutorial/TutorialBreakdown.svelte
+++ b/client/game/tutorial/TutorialBreakdown.svelte
@@ -87,7 +87,7 @@
 <table>
 	<tbody>
 		{#each properties as property, i}
-			<tr class="breakdown">
+			<tr>
 				{#each cards as card, i}
 					<td class="property">
 						{#if property == 'number'}
@@ -120,12 +120,7 @@
 				<td class="combined" style="transform:scale({resultScale})">
 					<CardSymbol {...combinedCard(card)} />
 				</td>
-				<td class="equality">
-					{#if i < cards.length - 1}
-						<TutorialEquality
-							equal={areCardsEqual(combinedCard(card), combinedCard(cards[i + 1]))} />
-					{/if}
-				</td>
+				<td />
 			{/each}
 			<td class="result">{isValidPlay(cards) ? 'yes' : 'no'}</td>
 		</tr>

--- a/client/home/HomeView.svelte
+++ b/client/home/HomeView.svelte
@@ -1,11 +1,11 @@
 <script>
 	import Tutorial from '../game/tutorial/Tutorial.svelte';
-	import { socket } from '../connectivity.js';
+	import { socket, requestRoomCreation } from '../connectivity.js';
 
 	let waiting = socket.connected;
 
 	function createRoom() {
-		socket.emit('createRoom', { open: false });
+		requestRoomCreation();
 		waiting = true;
 	}
 

--- a/client/main.js
+++ b/client/main.js
@@ -1,7 +1,7 @@
 import App from './App.svelte';
 
 const app = new App({
-	target: document.getElementById("app"),
+	target: document.getElementById('app'),
 	props: {},
 });
 

--- a/client/stores.js
+++ b/client/stores.js
@@ -1,0 +1,175 @@
+import { readable, writable } from 'svelte/store';
+import { socket } from './connectivity.js';
+import { cardAsString, inPlaceReplace } from './game/shared.js';
+
+const MAX_TICKER_COUNT = 10; // limit to prevent too much memory used
+
+export const playerName = writable(localStorage.getItem('name') || '');
+
+export const roomCode =
+	new URLSearchParams(window.location.search).get('room') || '';
+
+function onMultiple(events, callback) {
+	for (const event of events) {
+		socket.on(event, callback);
+	}
+}
+
+function offMultiple(events, callback) {
+	for (const event of events) {
+		socket.off(event, callback);
+	}
+}
+
+export const state = readable('joining', function start(set) {
+	function joinedSuccessfully(data) {
+		if (data.started) {
+			if (data.board.length > 0) {
+				set('playing');
+			} else {
+				set('ended');
+			}
+		} else {
+			set('waiting');
+		}
+	}
+	socket.on('joinedSuccessfully', joinedSuccessfully);
+
+	function roomStarted() {
+		set('playing');
+	}
+	socket.on('roomStarted', roomStarted);
+
+	function gameOver() {
+		set('ended');
+	}
+	socket.on('gameOver', gameOver);
+
+	return function stop() {
+		socket.off('joinedSuccessfully', joinedSuccessfully);
+		socket.off('roomStarted', roomStarted);
+		socket.off('gameOver', gameOver);
+	};
+});
+
+export const cards = readable([], function start(set) {
+	let cards = [];
+
+	const events = ['joinedSuccessfully', 'roomStarted', 'movePlayed'];
+	function update(data) {
+		cards = inPlaceReplace(
+			cards,
+			data.board.map(card => {
+				return {
+					shape: card.shape,
+					fillStyle: card.fillStyle,
+					color: card.color,
+					number: card.number,
+					id: cardAsString(card),
+				};
+			})
+		);
+		set(cards);
+	}
+	onMultiple(events, update);
+
+	return function stop() {
+		offMultiple(events, update);
+	};
+});
+
+export const players = readable([], function start(set) {
+	let players = [];
+
+	const events = ['joinedSuccessfully', 'roomStarted'];
+	function update(data) {
+		players = data.players;
+		set(players);
+	}
+	onMultiple(events, update);
+
+	function movePlayed(data) {
+		players = players.map(player => {
+			if (player.connectionId == data.player.connectionId) {
+				return data.player;
+			} else {
+				return player;
+			}
+		});
+		set(players);
+	}
+	socket.on('movePlayed', movePlayed);
+
+	function playerDisconnected(connectionId) {
+		players = players.map(player => {
+			if (player.connectionId == connectionId) {
+				player.connected = false;
+			}
+			return player;
+		});
+		set(players);
+	}
+	socket.on('playerDisconnected', playerDisconnected);
+
+	function playersRemoved(data) {
+		players = players.filter(
+			player => !data.removedPlayers.includes(player.connectionId)
+		);
+		set(players);
+	}
+	socket.on('playersRemoved', playersRemoved);
+
+	function newPlayer(player) {
+		players = [
+			{
+				connectionId: player.connectionId,
+				name: player.name,
+				points: player.points,
+				connected: player.connected,
+			},
+			...players.filter(
+				// remove old player if needed
+				oldPlayer => oldPlayer.connectionId != player.oldConnectionId
+			),
+		];
+		set(players);
+	}
+	socket.on('newPlayer', newPlayer);
+
+	return function stop() {
+		offMultiple(events, update);
+		socket.off('movePlayed', movePlayed);
+		socket.off('playerDisconnected', playerDisconnected);
+		socket.off('playersRemoved', playersRemoved);
+		socket.off('newPlayer', newPlayer);
+	};
+});
+
+export const plays = readable([], function start(set) {
+	let plays = [];
+
+	function roomStarted() {
+		plays = [];
+		set(plays);
+	}
+	socket.on('roomStarted', roomStarted);
+
+	function movePlayed(data) {
+		plays = [
+			{
+				cards: data.cards,
+				player: data.player.name,
+				valid: data.updated,
+				id: Math.random(),
+			},
+			...plays.slice(0, MAX_TICKER_COUNT),
+		];
+		set(plays);
+	}
+	socket.on('movePlayed', movePlayed);
+
+	return function stop() {
+		socket.off('roomStarted', roomStarted);
+		socket.off('movePlayed', movePlayed);
+	};
+});


### PR DESCRIPTION
Cut down on the number of places `socket` is referenced directly, ideally it wouldn't be used anywhere outside of `connectivity.js` and `stores.js`. State management is moved together more instead of having it spread across files (simplifies `GameView` a lot).