### PR TITLE
Disconnect inactive clients faster

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,10 @@ import { Card, Room } from './entity/room';
 const PORT = process.env.PORT || 3000;
 
 const app = http.createServer();
-const io = socketIo(app);
+const io = socketIo(app, {
+	pingInterval: 5000, // ping every 5 seconds
+	pingTimeout: 1000, // disconnect after not receiving a response
+});
 
 enum SocketEvent {
 	CREATE_ROOM = 'createRoom',


### PR DESCRIPTION
[By default, socket.io](https://socket.io/docs/server-api/) disconnects after 5 seconds without response and checks every 25 seconds. This disconnects clients quicker after they lose connection. This should improve the user experience if someone refreshes or otherwise tries to reconnect (they normally have to wait the server to realize they disconnected as they cannot join the same room twice).