### PR TITLE
Prevent too many cards when a clear results in an impossible board

### DIFF
--- a/server/controller/roomController.ts
+++ b/server/controller/roomController.ts
@@ -320,11 +320,14 @@ export class RoomController {
 		const needToClear =
 			room.votesToClear.length >= Math.round(connectedPlayers.length / 2);
 		if (needToClear) {
-			const { board } = room;
-			room.clearBoard();
 			room.votesToClear = [];
-			room.availableCards = shuffle(room.availableCards.concat(board));
-			room.placeCardsOnBoard(RoomController.INITIAL_BOARD_SIZE);
+			do {
+				room.availableCards = shuffle(
+					room.availableCards.concat(room.board)
+				);
+				room.clearBoard();
+				room.placeCardsOnBoard(RoomController.INITIAL_BOARD_SIZE);
+			} while (!findSetIn(...room.board) && !room.cantPlayAnotherMove());
 		}
 		await room.save();
 		return { room, cleared: needToClear };

--- a/server/entity/room.ts
+++ b/server/entity/room.ts
@@ -95,16 +95,9 @@ export class Room extends BaseEntity {
 	 */
 	placeCardsOnBoard(numCardsToDraw: number): void {
 		const { availableCards } = this;
-		const moveCardsToBoard = () => {
-			numCardsToDraw = Math.min(numCardsToDraw, availableCards.length);
-			const drawnCards = availableCards.splice(0, numCardsToDraw);
-			this.board.push(...drawnCards);
-		};
-
-		moveCardsToBoard();
-		while (!findSetIn(...this.board) && !this.cantPlayAnotherMove()) {
-			moveCardsToBoard();
-		}
+		numCardsToDraw = Math.min(numCardsToDraw, availableCards.length);
+		const drawnCards = availableCards.splice(0, numCardsToDraw);
+		this.board.push(...drawnCards);
 		this.availableCards = availableCards;
 	}
 


### PR DESCRIPTION
When a clear results in a board without sets, drawnCards are added to the board multiple times, resulting in more than 12 cards being shown after clearing. This prevents this.